### PR TITLE
Fix race that reset editor content

### DIFF
--- a/Sync.Mono/Components/Pages/Editor.razor
+++ b/Sync.Mono/Components/Pages/Editor.razor
@@ -236,11 +236,14 @@
 
         try
         {
+            _isProcessingChange = true;
             await EditorService.UpdateEditorStateAsync(_editorState.Id, _content);
+            _isProcessingChange = false;
         }
         catch (Exception ex)
         {
             Console.WriteLine($"Error sending content update: {ex.Message}");
+            _isProcessingChange = false;
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent sync timer from overwriting in-progress edits

## Testing
- `dotnet build Sync.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5745b74832faf28c026d1e2055f