### PR TITLE
Add cut/copy buttons

### DIFF
--- a/Sync.Mono/Components/Pages/Editor.razor
+++ b/Sync.Mono/Components/Pages/Editor.razor
@@ -36,6 +36,10 @@
             <div class="editor-wrapper">
                 <div class="editor-header">
                     <div class="header-left">
+                        <div class="cut-copy-buttons">
+                            <button class="btn-dark btn-exit" @onclick="CutContent">CUT</button>
+                            <button class="btn-dark btn-exit" @onclick="CopyContent">COPY</button>
+                        </div>
                         <div class="session-info">
                             <div class="connection-info">
                                 <span class="connection-indicator @(_connectionStatus == "Connected" ? "connected" : "disconnected")"></span>
@@ -258,6 +262,22 @@
         catch (Exception ex)
         {
             Console.WriteLine($"Error sending language update: {ex.Message}");
+        }
+    }
+
+    private async Task CopyContent()
+    {
+        await JSRuntime.InvokeVoidAsync("clipboardInterop.copyText", _content);
+    }
+
+    private async Task CutContent()
+    {
+        await JSRuntime.InvokeVoidAsync("clipboardInterop.copyText", _content);
+        _content = string.Empty;
+
+        if (_editorState != null)
+        {
+            await EditorService.UpdateEditorStateAsync(_editorState.Id, _content);
         }
     }
 
@@ -507,8 +527,13 @@
         background-color: #dc3545;
     }
 
-    .language-selector, .users-info {
+    .language-selector, .users-info, .cut-copy-buttons {
         margin-right: 20px;
+    }
+
+    .cut-copy-buttons {
+        display: flex;
+        gap: 10px;
     }
 
     .dark-select {

--- a/Sync.Mono/Pages/_Host.cshtml
+++ b/Sync.Mono/Pages/_Host.cshtml
@@ -16,6 +16,7 @@
     
     <!-- Custom scripts -->
     <script src="js/websocket.js"></script>
+    <script src="js/clipboard.js"></script>
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
 <body>

--- a/Sync.Mono/wwwroot/js/clipboard.js
+++ b/Sync.Mono/wwwroot/js/clipboard.js
@@ -1,0 +1,16 @@
+window.clipboardInterop = {
+    copyText: function(text) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text);
+        } else {
+            var textarea = document.createElement('textarea');
+            textarea.value = text;
+            textarea.style.position = 'fixed';
+            document.body.appendChild(textarea);
+            textarea.focus();
+            textarea.select();
+            try { document.execCommand('copy'); } catch (err) {}
+            document.body.removeChild(textarea);
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add copy and cut buttons in the editor header
- provide new clipboard interop script and link it in host page
- update styles for the new buttons

## Testing
- `dotnet build Sync.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840a76fce70832fa77f5bdbc90426d2