### PR TITLE
Add blue copy and cut buttons

### DIFF
--- a/Sync.Mono/Components/Pages/Editor.razor
+++ b/Sync.Mono/Components/Pages/Editor.razor
@@ -37,8 +37,8 @@
                 <div class="editor-header">
                     <div class="header-left">
                         <div class="cut-copy-buttons">
-                            <button class="btn-dark btn-exit" @onclick="CutContent">CUT</button>
-                            <button class="btn-dark btn-exit" @onclick="CopyContent">COPY</button>
+                            <button class="btn-dark btn-blue" @onclick="CutContent">CUT</button>
+                            <button class="btn-dark btn-blue" @onclick="CopyContent">COPY</button>
                         </div>
                         <div class="session-info">
                             <div class="connection-info">
@@ -565,6 +565,15 @@
 
     .btn-exit {
         background-color: #dc3545;
+    }
+
+    .btn-blue {
+        background-color: #007bff;
+        color: white;
+        border: none;
+        padding: 6px 12px;
+        border-radius: 4px;
+        cursor: pointer;
     }
 
     .editor-content {


### PR DESCRIPTION
## Summary
- change copy/cut buttons to use new blue style
- style `.btn-blue` with blue background color

## Testing
- `dotnet build Sync.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d33b735c832f887dc3e74cd09195